### PR TITLE
ADD - Reveal re-signed IPA in Finder

### DIFF
--- a/SwiftReSign/Resources/Info.plist
+++ b/SwiftReSign/Resources/Info.plist
@@ -14,6 +14,8 @@
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleDisplayName</key>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/SwiftReSign/Resources/resign.sh
+++ b/SwiftReSign/Resources/resign.sh
@@ -114,3 +114,6 @@ rm "$TMPDIR/provisioning.plist"
 rm "$TMPDIR/entitlements.plist"
 
 echo "SUCCESS"
+
+# Reveal resigned IPA file in the Finder.
+open -R "$OUTDIR/$filename"


### PR DESCRIPTION
Reveals the re-signed IPA file in the Finder when the operation completes successfully. In addition, the 'CFBundleDisplayName' key was added to the Info.plist file, in order to use its value as the title of any alert presented to the user. 